### PR TITLE
setup.py: Switch readline to use gnureadline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ sysplat = str(sys.platform).lower()
 
 install_requires = ['setuptools'] 
 if 'darwin' in sysplat:
-    install_requires += ['readline'] 
+    install_requires += ['gnureadline']
 if 'win32' in sysplat:
     install_requires += ['pyreadline'] 
 


### PR DESCRIPTION
The readline package was renamed to gnureadline.

Closes https://github.com/pombredanne/anyreadline/issues/3